### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,6 +24,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -35,6 +41,9 @@ jobs:
   #publish-gpr:
   #  needs: build
   #  runs-on: ubuntu-latest
+  #  permissions:
+  #    contents: read
+  #    packages: write
   #  steps:
   #    - uses: actions/checkout@v4
   #    - uses: actions/setup-node@v3


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrainst/node-red-contrib-parser-ini/security/code-scanning/1](https://github.com/alexandrainst/node-red-contrib-parser-ini/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. The `build` job only needs `contents: read` to check out the repository and run tests. The `publish-npm` job requires `contents: read` and `packages: write` to publish the package to npm. The commented-out `publish-gpr` job will also be updated for consistency, even though it is currently inactive.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
