### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrainst/node-red-contrib-parser-ini/security/code-scanning/2](https://github.com/alexandrainst/node-red-contrib-parser-ini/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs basic CI tasks (checking out the repository, setting up Node.js, installing dependencies, building, and testing), it only requires `contents: read` permissions. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
