### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -21,6 +23,8 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrainst/node-red-contrib-parser-ini/security/code-scanning/3](https://github.com/alexandrainst/node-red-contrib-parser-ini/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for each job. For the `build` job, only `contents: read` is needed to check out the repository and run tests. For the `publish-npm` job, `contents: read` is sufficient since the `NODE_AUTH_TOKEN` secret is used for npm publishing, and no additional permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
